### PR TITLE
Add landing page (#13)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,14 @@ gem 'devise'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-hocus-pocus'
+  gem 'rails-assets-font-awesome'
 end
 
 group :development, :test do
   gem 'byebug', platform: :mri
   gem 'rspec-rails', '~> 3.4'
+  gem 'rails-controller-testing'
+  gem 'capybara'
   gem 'factory_girl_rails', '~> 4.7'
   gem 'faker', '~> 1.6.5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -39,10 +39,18 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.0.0)
     bcrypt (3.1.11)
     builder (3.2.2)
     byebug (9.0.5)
+    capybara (2.7.1)
+      addressable
+      mime-types (>= 1.16)
+      nokogiri (>= 1.3.3)
+      rack (>= 1.0.0)
+      rack-test (>= 0.5.4)
+      xpath (~> 2.0)
     concurrent-ruby (1.0.2)
     debug_inspector (0.0.2)
     devise (4.2.0)
@@ -105,7 +113,12 @@ GEM
       bundler (>= 1.3.0, < 2.0)
       railties (= 5.0.0)
       sprockets-rails (>= 2.0.0)
+    rails-assets-font-awesome (4.6.3)
     rails-assets-hocus-pocus (0.2.10)
+    rails-controller-testing (0.1.1)
+      actionpack (~> 5.x)
+      actionview (~> 5.x)
+      activesupport (~> 5.x)
     rails-dom-testing (2.0.1)
       activesupport (>= 4.2.0, < 6.0)
       nokogiri (~> 1.6.0)
@@ -174,12 +187,15 @@ GEM
     websocket-driver (0.6.4)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
+    xpath (2.0.0)
+      nokogiri (~> 1.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   byebug
+  capybara
   devise
   factory_girl_rails (~> 4.7)
   faker (~> 1.6.5)
@@ -188,7 +204,9 @@ DEPENDENCIES
   pg (~> 0.18)
   puma (~> 3.0)
   rails (~> 5.0.0)
+  rails-assets-font-awesome!
   rails-assets-hocus-pocus!
+  rails-controller-testing
   rspec-rails (~> 3.4)
   sass-rails (~> 5.0)
   turbolinks (~> 5)

--- a/app/assets/images/browser.svg
+++ b/app/assets/images/browser.svg
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="700px" height="440px" viewBox="0 0 700 440" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 3.8.3 (29802) - http://www.bohemiancoding.com/sketch -->
+    <title>Browser Window</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <rect id="path-1" x="0" y="0" width="700" height="440" rx="7"></rect>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="Landing" transform="translate(-370.000000, -170.000000)">
+            <g id="Browser-Window" transform="translate(370.000000, 170.000000)">
+                <mask id="mask-2" fill="white">
+                    <use xlink:href="#path-1"></use>
+                </mask>
+                <use id="Mask" fill="#FCFCFC" xlink:href="#path-1"></use>
+                <rect id="Window-Bar" fill="#DFE6EC" mask="url(#mask-2)" x="0" y="0" width="700" height="30"></rect>
+                <circle id="Oval-1" fill="#FF564F" mask="url(#mask-2)" cx="19" cy="15" r="7"></circle>
+                <circle id="Oval-1-Copy" fill="#FFB429" mask="url(#mask-2)" cx="43" cy="15" r="7"></circle>
+                <circle id="Oval-1-Copy-2" fill="#25C63A" mask="url(#mask-2)" cx="67" cy="15" r="7"></circle>
+            </g>
+        </g>
+    </g>
+</svg>

--- a/app/assets/stylesheets/_box.scss
+++ b/app/assets/stylesheets/_box.scss
@@ -1,0 +1,11 @@
+.box {
+  margin-top: double(-$spacing-unit);
+  margin-bottom: double($spacing-unit);
+
+  border-radius: $ui-border-radius;
+
+  &.box-informative {
+    color: #FFFFFF;
+    background: $color-informative;
+  }
+}

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -1,0 +1,14 @@
+input[type="button"], input[type="submit"], button, .btn {
+  padding: 12px 30px;
+
+  &.btn-big {
+    margin: $spacing-unit 0;
+    padding: 18px 40px;
+    border-radius: 180px;
+
+    text-transform: uppercase;
+    font-size: 1rem;
+    font-weight: bold;
+    letter-spacing: 0.44px;
+  }
+}

--- a/app/assets/stylesheets/_colors.scss
+++ b/app/assets/stylesheets/_colors.scss
@@ -1,0 +1,11 @@
+$brand-color: #5BB4B4;
+$secondary-color: #042A2B;
+
+$navbar-background: $secondary-color;
+$navbar-color: #FFFFFF;
+
+$color-btn: $brand-color;
+
+$color-informative: $brand-color;
+
+$footer-text-color: lighten($secondary-color, 20%);

--- a/app/assets/stylesheets/_font-awesome.scss
+++ b/app/assets/stylesheets/_font-awesome.scss
@@ -1,0 +1,2 @@
+$fa-font-path: "/assets/font-awesome/fonts";
+@import "font-awesome/font-awesome.scss";

--- a/app/assets/stylesheets/_footer.scss
+++ b/app/assets/stylesheets/_footer.scss
@@ -1,0 +1,20 @@
+.main-footer {
+  @include font-size($font-size-small);
+
+  color: $footer-text-color;
+  background: $secondary-color;
+
+  line-height: calc(60px - ($spacing-unit * 2));
+  text-transform: uppercase;
+  font-weight: bold;
+
+  p {
+    margin: 0;
+    padding-left: halve($grid-gutter);
+  }
+
+  a {
+    color: $footer-text-color;
+    text-decoration: none;
+  }
+}

--- a/app/assets/stylesheets/_landing.scss
+++ b/app/assets/stylesheets/_landing.scss
@@ -1,0 +1,14 @@
+.home.index {
+  background: $secondary-color;
+}
+
+.landing {
+  padding: 0 0 40px 0;
+
+  color: #FFFFFF;
+  text-align: center;
+
+  .landing-browser {
+    max-width: 100%;
+  }
+}

--- a/app/assets/stylesheets/_navigation.scss
+++ b/app/assets/stylesheets/_navigation.scss
@@ -1,0 +1,59 @@
+.navbar {
+  .navbar-left {
+    flex-direction: row !important;
+    justify-content: space-between !important;
+
+    .navbar-link {
+      @include font-size-heading(1, $font-size-h3);
+
+      float: left;
+      margin: 0;
+
+      font-weight: bold;
+    }
+  }
+
+  .navbar-btn {
+    @include font-size-heading(1, $font-size-h3);
+    @include ui-padding;
+
+    float: right;
+    margin: 0;
+    background: none;
+
+    font-size: 1.2rem;
+  }
+
+  .navbar-right {
+    text-align: right;
+
+    .navbar-menu > li > a {
+      @include font-size($font-size-small);
+
+      padding: ($ui-padding-vertical * 2) ($ui-padding-horizontal * 2);
+
+      letter-spacing: 0.03rem;
+      text-transform: uppercase;
+      font-weight: 900;
+    }
+  }
+}
+
+@include rwd("mobile") {
+  .navbar {
+    .navbar-menu {
+      display: none;
+
+      li {
+        @include ui-padding;
+
+        display: block;
+        text-align: left;
+      }
+    }
+
+    #navbar-checkbox:checked ~ .grid-item .navbar-menu {
+      display: block;
+    }
+  }
+}

--- a/app/assets/stylesheets/_variables.scss
+++ b/app/assets/stylesheets/_variables.scss
@@ -1,0 +1,9 @@
+$rwd-type: desktop-first;
+$rwd-map: (
+  "mobile": 630px
+);
+
+$font-family-base: 'Lato', sans-serif;
+$btn-flat: true;
+
+$sticky-footer-height: 60px;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,17 @@
+@import "colors";
+@import "variables";
+
 @import "hocus-pocus";
+
+@import "_font-awesome";
+@import "navigation";
+@import "buttons";
+@import "footer";
+@import "box";
+@import "landing";
+
+@import url(https://fonts.googleapis.com/css?family=Lato:400,700,900);
+
+body {
+  font-family: "Lato", sans-serif;
+}

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,0 +1,4 @@
+class HomeController < ApplicationController
+  def index
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  # Used for styling <body> on specific pages.
+  def current_context
+    "#{controller_name} #{action_name}"
+  end
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,0 +1,8 @@
+<div class="landing grid grid-center">
+  <main class="grid-item 2/3 mobile-1/1">
+    <%= image_tag "browser.svg", alt: "Browser illustration", class: "landing-browser" %>
+
+    <h1 class="landing-slogan">Manage your projects like never before.</h1>
+    <%= link_to "Get started", new_user_registration_path, class: "btn btn-big" %>
+  </main>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,15 +2,24 @@
 <html>
   <head>
     <title>Bulbulator</title>
+
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
     <%= csrf_meta_tags %>
 
     <%= stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_include_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
 
-  <body>
-    <p class="notice"><%= notice %></p>
-    <p class="alert"><%= alert %></p>
-    <%= yield %>
+  <body class="<%= current_context %>">
+    <%= render "shared/navigation" %>
+
+    <div class="container">
+      <%= render "shared/flash" %>
+
+      <%= yield %>
+    </div>
+
+    <%= render "shared/footer" %>
   </body>
 </html>

--- a/app/views/shared/_flash.html.erb
+++ b/app/views/shared/_flash.html.erb
@@ -1,0 +1,13 @@
+<div class="grid grid-center">
+  <% if notice %>
+    <div class="grid-item 3/4 mobile-1/1 box box-informative">
+      <p><%= notice %></p>
+    </div>
+  <% end %>
+
+  <% if alert %>
+    <div class="grid-item 3/4 mobile-1/1 box box-negative">
+      <p><%= alert %></p>
+    </div>
+  <% end %>
+</div>

--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -1,0 +1,12 @@
+<footer class="main-footer sticky-footer">
+  <div class="container">
+    <div class="grid grid-pair">
+      <p class="grid-item 1/2">
+        &copy; <%= Date.today.year %> Bulbulator Team
+      </p>
+      <p class="grid-item 1/2">
+        <%= link_to "Fork on GitHub", "https://github.com/Ragnarson-Internship2016/group-II" %>
+      </p>
+    </div>
+  </div>
+</footer>

--- a/app/views/shared/_navigation.html.erb
+++ b/app/views/shared/_navigation.html.erb
@@ -1,0 +1,26 @@
+<nav class="navbar">
+  <div class="container">
+    <div class="grid grid-pair">
+      <div class="grid-item 2/4 mobile-3/4 navbar-left">
+        <%= link_to "Bulbulator", root_path, class: "navbar-link" %>
+      </div>
+
+      <label for="navbar-checkbox" class="grid-item mobile-1/4 btn navbar-btn hidden mobile-visible">
+        <i class="fa fa-bars"></i>
+      </label>
+      <input type="checkbox" id="navbar-checkbox" class="hidden">
+
+      <div class="grid-item 2/4 mobile-1/1 navbar-right">
+        <ul class="navbar-menu">
+          <% if user_signed_in? %>
+            <li><%= link_to "Logout", destroy_user_session_path, method: :delete %></li>
+            <li><%= link_to "Add task", root_path, class: "btn" %></li>
+          <% else %>
+            <li><%= link_to "Sign in", new_user_session_path %></li>
+            <li><%= link_to "Join for free", new_user_registration_path, class: "btn" %></li>
+          <% end %>
+        </ul>
+      </div>
+    </div>
+  </div>
+</nav>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users, controllers: { registrations: 'registrations' }
+
+  root 'home#index'
 end

--- a/spec/controllers/home_controller_spec.rb
+++ b/spec/controllers/home_controller_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe HomeController, type: :controller do
+  describe "GET #index" do
+    before do
+      get :index
+    end
+
+    it "returns http success" do
+      expect(response).to have_http_status(:success)
+    end
+
+    it "renders landing page" do
+      expect(response).to render_template(:index)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../../config/environment', __FILE__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'spec_helper'
 require 'rspec/rails'
+require 'capybara/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in

--- a/spec/views/home/index.html.erb_spec.rb
+++ b/spec/views/home/index.html.erb_spec.rb
@@ -1,0 +1,19 @@
+require 'rails_helper'
+
+RSpec.describe "home/index.html.erb", type: :view do
+  before do
+    render
+  end
+
+  it "has img tag with browser vector" do
+    expect(rendered).to have_css("img.landing-browser[src*='/assets/browser']")
+  end
+
+  it "has h1 slogan with proper class" do
+    expect(rendered).to have_css("h1.landing-slogan")
+  end
+
+  it "has 'Get started' link to sign up" do
+    expect(rendered).to have_link("Get started", href: "/users/sign_up")
+  end
+end


### PR DESCRIPTION
* Added `HomeController` for static pages.
* Added `index` action for `HomeController`.
* Added `index` view with landing page.
* Added stylesheets for landing and to customize hocus-pocus.
* Added navigation partial.
* Added footer partial.
* Added `current_context` method in `ApplicationHelper`.
* Set root route to `home#index`.
* Added font-awesome to Gemfile.
* Added controller and view tests.

Closes #13.